### PR TITLE
Add job with --days-recent=360 to task_schedule

### DIFF
--- a/fss_check/task_schedule.cfg
+++ b/fss_check/task_schedule.cfg
@@ -37,6 +37,9 @@ alert       aca@head.cfa.harvard.edu
       exec fss_check_daily_fss --out $ENV{SKA}/data/fss_check3 --email=aca_alert\@cfa.harvard.edu
       exec /bin/cp -p $ENV{SKA}/data/fss_check3/index.html /data/mta4/www/ASPECT/fss_check3/
       exec /bin/cp -p $ENV{SKA}/data/fss_check3/*.png /data/mta4/www/ASPECT/fss_check3/
+      exec fss_check_daily_fss --days-recent=360 --out $ENV{SKA}/data/fss_check3/days-recent-360 --email=aca_alert\@cfa.harvard.edu
+      exec /bin/cp -p $ENV{SKA}/data/fss_check3/days-recent-360/index.html /data/mta4/www/ASPECT/fss_check3/days-recent-360/
+      exec /bin/cp -p $ENV{SKA}/data/fss_check3/days-recent-360/*.png /data/mta4/www/ASPECT/fss_check3/days-recent-360/
       context 1
       <check>
         <error>

--- a/fss_check/task_schedule.cfg
+++ b/fss_check/task_schedule.cfg
@@ -35,11 +35,11 @@ alert       aca@head.cfa.harvard.edu
       cron * * * * *
       check_cron * * * * *
       exec fss_check_daily_fss --out $ENV{SKA}/data/fss_check3 --email=aca_alert\@cfa.harvard.edu
-      exec /bin/cp -p $ENV{SKA}/data/fss_check3/index.html /data/mta4/www/ASPECT/fss_check3/
-      exec /bin/cp -p $ENV{SKA}/data/fss_check3/*.png /data/mta4/www/ASPECT/fss_check3/
+      exec /bin/cp -p $ENV{SKA}/data/fss_check3/index.html $ENV{SKA}/www/ASPECT/fss_check3/
+      exec /bin/cp -p $ENV{SKA}/data/fss_check3/*.png $ENV{SKA}/www/ASPECT/fss_check3/
       exec fss_check_daily_fss --days-recent=360 --out $ENV{SKA}/data/fss_check3/days-recent-360
-      exec /bin/cp -p $ENV{SKA}/data/fss_check3/days-recent-360/index.html /data/mta4/www/ASPECT/fss_check3/days-recent-360/
-      exec /bin/cp -p $ENV{SKA}/data/fss_check3/days-recent-360/*.png /data/mta4/www/ASPECT/fss_check3/days-recent-360/
+      exec /bin/cp -p $ENV{SKA}/data/fss_check3/days-recent-360/index.html $ENV{SKA}/www/ASPECT/fss_check3/days-recent-360/
+      exec /bin/cp -p $ENV{SKA}/data/fss_check3/days-recent-360/*.png $ENV{SKA}/www/ASPECT/fss_check3/days-recent-360/
       context 1
       <check>
         <error>

--- a/fss_check/task_schedule.cfg
+++ b/fss_check/task_schedule.cfg
@@ -35,9 +35,11 @@ alert       aca@head.cfa.harvard.edu
       cron * * * * *
       check_cron * * * * *
       exec fss_check_daily_fss --out $ENV{SKA}/data/fss_check3 --email=aca_alert\@cfa.harvard.edu
+      exec /bin/mkdir -p $ENV{SKA}/www/ASPECT/fss_check3
       exec /bin/cp -p $ENV{SKA}/data/fss_check3/index.html $ENV{SKA}/www/ASPECT/fss_check3/
       exec /bin/cp -p $ENV{SKA}/data/fss_check3/*.png $ENV{SKA}/www/ASPECT/fss_check3/
       exec fss_check_daily_fss --days-recent=360 --out $ENV{SKA}/data/fss_check3/days-recent-360
+      exec /bin/mkdir -p $ENV{SKA}/www/ASPECT/fss_check3/days-recent-360
       exec /bin/cp -p $ENV{SKA}/data/fss_check3/days-recent-360/index.html $ENV{SKA}/www/ASPECT/fss_check3/days-recent-360/
       exec /bin/cp -p $ENV{SKA}/data/fss_check3/days-recent-360/*.png $ENV{SKA}/www/ASPECT/fss_check3/days-recent-360/
       context 1

--- a/fss_check/task_schedule.cfg
+++ b/fss_check/task_schedule.cfg
@@ -37,7 +37,7 @@ alert       aca@head.cfa.harvard.edu
       exec fss_check_daily_fss --out $ENV{SKA}/data/fss_check3 --email=aca_alert\@cfa.harvard.edu
       exec /bin/cp -p $ENV{SKA}/data/fss_check3/index.html /data/mta4/www/ASPECT/fss_check3/
       exec /bin/cp -p $ENV{SKA}/data/fss_check3/*.png /data/mta4/www/ASPECT/fss_check3/
-      exec fss_check_daily_fss --days-recent=360 --out $ENV{SKA}/data/fss_check3/days-recent-360 --email=aca_alert\@cfa.harvard.edu
+      exec fss_check_daily_fss --days-recent=360 --out $ENV{SKA}/data/fss_check3/days-recent-360
       exec /bin/cp -p $ENV{SKA}/data/fss_check3/days-recent-360/index.html /data/mta4/www/ASPECT/fss_check3/days-recent-360/
       exec /bin/cp -p $ENV{SKA}/data/fss_check3/days-recent-360/*.png /data/mta4/www/ASPECT/fss_check3/days-recent-360/
       context 1


### PR DESCRIPTION
## Description

This adds a new sub-directory of outputs using `--days-recent=360` with plots that PCAD will use in their bi-annual report.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
No impact to existing files or interface.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
For functional testing, made a conda package at 00d2bff and installed it in linux conda env for testing trending / non-fsds packages, with symbolic links set for the www/ASPECT/fss_check3 output to point to a test_review_outputs directory.
```
conda install /proj/sot/ska/jeanproj/git/skare3/builds/linux-64/fss_check-1.0.1.dev5+g00d2bff-py310_0.tar.bz2
skare task_schedule3.pl -package fss_check
```
Output at
https://icxc.cfa.harvard.edu/aspect/test_review_outputs/fss_check-pr22/
and
https://icxc.cfa.harvard.edu/aspect/test_review_outputs/fss_check-pr22/days-recent-360/
